### PR TITLE
Fix undefined index: pathinfo(...)['extension']

### DIFF
--- a/lib/Analyzer/FileCorruptionAnalyzer.php
+++ b/lib/Analyzer/FileCorruptionAnalyzer.php
@@ -85,7 +85,7 @@ class FileCorruptionAnalyzer
             $pathInfo = pathinfo($node->getPath());
             foreach ($signatures as $signature) {
                 $isFileCorrupted = true;
-                if (in_array(strtolower($pathInfo['extension']), $signature['extensions'])) {
+                if (isset($pathInfo['extension']) && in_array(strtolower($pathInfo['extension']), $signature['extensions'])) {
                     // txt file extension has no signature, but is not corrupted
                     if (array_key_exists('exists', $signature['signature'])) {
                         if ($signature['signature']['exists'] === false) {

--- a/lib/Analyzer/FileExtensionAnalyzer.php
+++ b/lib/Analyzer/FileExtensionAnalyzer.php
@@ -91,6 +91,6 @@ class FileExtensionAnalyzer
     {
         $file = pathinfo($fileName);
 
-        return $file['extension'];
+        return isset($file['extension']) ? $file['extension'] : '';
     }
 }

--- a/lib/Analyzer/FileTypeFunnellingAnalyzer.php
+++ b/lib/Analyzer/FileTypeFunnellingAnalyzer.php
@@ -62,8 +62,10 @@ class FileTypeFunnellingAnalyzer
                         }
                         $numberOfKnownFileExtensions += $this->countKnownFileExtensions($file);
                         $pathInfo = pathinfo($file->getOriginalName());
-                        $writtenExtensions[$pathInfo['extension']] = 1;
-                        $writtenFiles[] = $file;
+                        if (isset($pathInfo['extension'])) {
+                            $writtenExtensions[$pathInfo['extension']] = 1;
+                            $writtenFiles[] = $file;
+                        }
                         if ($file->getCorrupted()) {
                             $corruptedFiles[] = $file;
                         }
@@ -74,7 +76,9 @@ class FileTypeFunnellingAnalyzer
                         break;
                     case Monitor::DELETE:
                         $pathInfo = pathinfo($file->getOriginalName());
-                        $deletedExtensions[] = $pathInfo['extension'];
+                        if (isset($pathInfo['extension'])) {
+                            $deletedExtensions[] = $pathInfo['extension'];
+                        }
                         break;
                     case Monitor::CREATE:
                         break;


### PR DESCRIPTION
I just saw a lot log messages in my error logs and figured out, that PHPs pathinfo(...) returns index "extension"  **if any** extension is present only.

Documentation: http://php.net/manual/function.pathinfo.php
Error message: `Undefined index: extension at [...]/apps/ransomware_detection/lib/Analyzer/FileCorruptionAnalyzer.php#88`